### PR TITLE
Fix pyzbar pip3 installation URL (add missing "git+" prefix)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ python3 -m pip install --upgrade setuptools
 sudo apt-get install python3-tk
 sudo apt install libzbar0
 pip3 install git+https://github.com/jreesun/urtypes.git@e0d0db277ec2339650343eaf7b220fffb9233241
-pip3 install -e https://github.com/enteropositivo/pyzbar.git@a52ff0b2e8ff714ba53bbf6461c89d672a304411#egg=pyzbar
+pip3 install -e git+https://github.com/enteropositivo/pyzbar.git@a52ff0b2e8ff714ba53bbf6461c89d672a304411#egg=pyzbar
 pip3 install embit dataclasses qrcode tk opencv-python
 ```
 


### PR DESCRIPTION
Following the instructions for installing the Python requirements on Ubuntu 22.04, I got the following error on trying to install pyzbar:
```
$ pip3 install -e https://github.com/enteropositivo/pyzbar.git@a52ff0b2e8ff714ba53bbf6461c89d672a304411#egg=pyzbar
Defaulting to user installation because normal site-packages is not writeable
ERROR: https://github.com/enteropositivo/pyzbar.git@a52ff0b2e8ff714ba53bbf6461c89d672a304411#egg=pyzbar is not a valid editable requirement. It should either be a path to a local project or a VCS URL (beginning with bzr+http, bzr+https, bzr+ssh, bzr+sftp, bzr+ftp, bzr+lp, bzr+file, git+http, git+https, git+ssh, git+git, git+file, hg+file, hg+http, hg+https, hg+ssh, hg+static-http, svn+ssh, svn+http, svn+https, svn+svn, svn+file).
```

Using "git+https" instead of only "https" for the URI fixed this:

```
$ pip3 install -e git+https://github.com/enteropositivo/pyzbar.git@a52ff0b2e8ff714ba53bbf6461c89d672a304411#egg=pyzbar
Defaulting to user installation because normal site-packages is not writeable
Obtaining pyzbar from git+https://github.com/enteropositivo/pyzbar.git@a52ff0b2e8ff714ba53bbf6461c89d672a304411#egg=pyzbar
 Cloning https://github.com/enteropositivo/pyzbar.git (to revision a52ff0b2e8ff714ba53bbf6461c89d672a304411) to ./src/pyzbar
Running command git clone --filter=blob:none --quiet https://github.com/enteropositivo/pyzbar.git /home/thestack/seedsigner-emulator/src/pyzbar
Running command git rev-parse -q --verify 'sha^a52ff0b2e8ff714ba53bbf6461c89d672a304411'
Running command git fetch -q https://github.com/enteropositivo/pyzbar.git a52ff0b2e8ff714ba53bbf6461c89d672a304411
Resolved https://github.com/enteropositivo/pyzbar.git to commit a52ff0b2e8ff714ba53bbf6461c89d672a304411
Preparing metadata (setup.py) ... done
Installing collected packages: pyzbar
Running setup.py develop for pyzbar
Successfully installed pyzbar-0.1.9
```