### PR TITLE
Fix seedsigner pr741 compatibility

### DIFF
--- a/seedsigner/emulator/desktopDisplay.py
+++ b/seedsigner/emulator/desktopDisplay.py
@@ -152,7 +152,9 @@ class desktopDisplay(threading.Thread):
         self.label.image=self.tkimage
         self.label.place(x=125, y=10)
        
-        
+    show_image = ShowImage  # Alias to call "ShowImage" as "show_image" (compatibility with the merged SeedSigner PR #741)
+
+
     def clear(self):
         """Clear contents of image buffer"""
  

--- a/seedsigner/emulator/desktopDisplay.py
+++ b/seedsigner/emulator/desktopDisplay.py
@@ -19,15 +19,22 @@ from PIL import ImageTk
 import threading
 import os
 
-EMULATOR_VERSION = '0.5'
+EMULATOR_VERSION = '0.75'
         
+DISPLAY_TYPE__ST7789 = "st7789"
+DISPLAY_TYPE__ILI9341 = "ili9341"
+DISPLAY_TYPE__ILI9486 = "ili9486"
+
+ALL_DISPLAY_TYPES = [DISPLAY_TYPE__ST7789, DISPLAY_TYPE__ILI9341, DISPLAY_TYPE__ILI9486]
+
 
 class desktopDisplay(threading.Thread):
     """class for desktop display."""
     root=0
-    def __init__(self):
-        self.width = 240
-        self.height = 240
+    def __init__(self, display_type: str = DISPLAY_TYPE__ST7789, width: int = 240, height: int = 240):
+        self.width = width
+        self.height = height
+        self.display_type = display_type
 
         # Multithreading
         threading.Thread.__init__(self)
@@ -56,7 +63,7 @@ class desktopDisplay(threading.Thread):
         self.root.title(title)
 
         self.root.protocol("WM_DELETE_WINDOW", self.callback)
-        self.root.geometry("480x260+240+240")
+        self.root.geometry(f"{self.width*2}x{self.height+20}+240+240")
         self.root.configure(bg='orange')
         self.root.iconphoto(False, tk.PhotoImage(file='seedsigner/resources/icons/emulator_icon.png'))
         # ....
@@ -94,15 +101,15 @@ class desktopDisplay(threading.Thread):
         self.bindButtonClick(self.btnD)
 
         self.btn1 = Button(self.root, image=pixel,  width=40, height=20,  command = HardwareButtons.KEY1_PIN, bg='white')
-        self.btn1.place(x=400, y=60)
+        self.btn1.place(x=self.width+160, y=60) # Button position dinamically (compatibility with the merged SeedSigner PR #741)
         self.bindButtonClick(self.btn1)
 
         self.btn2 = Button(self.root, image=pixel,  width=40, height=20,  command = HardwareButtons.KEY2_PIN, bg='white')
-        self.btn2.place(x=400, y=116)
+        self.btn2.place(x=self.width+160, y=116) # Button position dinamically (compatibility with the merged SeedSigner PR #741)
         self.bindButtonClick(self.btn2)
 
         self.btn3 = Button(self.root, image=pixel,  width=40, height=20,  command = HardwareButtons.KEY3_PIN, bg='white')
-        self.btn3.place(x=400, y=172)
+        self.btn3.place(x=self.width+160, y=172) # Button position dinamically (compatibility with the merged SeedSigner PR #741)
         self.bindButtonClick(self.btn3)
 
         
@@ -144,7 +151,12 @@ class desktopDisplay(threading.Thread):
         while(self.root==0): time.sleep(0.1)
         imwidth, imheight = Image2.size
         if imwidth != self.width or imheight != self.height:
-            raise ValueError('Image must be same dimensions as display \
+            if self.display_type == DISPLAY_TYPE__ILI9341: # Re-adapt Image when ILI9341 is selected (compatibility with the merged SeedSigner PR #741)
+                # Rotates image for ILI9341(320x240)
+                Image2 = Image2.rotate(90, expand=True)
+                Image2 = Image2.resize((self.width, self.height))
+            else:                
+                raise ValueError('Image must be same dimensions as display \
                 ({0}x{1}).' .format(self.width, self.height))
 
         self.tkimage= ImageTk.PhotoImage(Image2, master=self.root)
@@ -153,6 +165,17 @@ class desktopDisplay(threading.Thread):
         self.label.place(x=125, y=10)
        
     show_image = ShowImage  # Alias to call "ShowImage" as "show_image" (compatibility with the merged SeedSigner PR #741)
+
+    def update_geometry(self): # (compatibility with the merged SeedSigner PR #741)
+        """Update window size dynamically"""
+        self.root.geometry(f"{self.width*2}x{self.height+20}+240+240")
+        self.btn1.place(x=self.width+160, y=60)
+        self.btn2.place(x=self.width+160, y=116)
+        self.btn3.place(x=self.width+160, y=172)
+
+    def invert(self, enabled: bool = True): # (compatibility with the merged SeedSigner PR #741)
+        """Invert how the display interprets colors"""
+        pass #self.display.invert(enabled)
 
 
     def clear(self):

--- a/seedsigner/gui/renderer.py
+++ b/seedsigner/gui/renderer.py
@@ -4,7 +4,14 @@ from threading import Lock
 #from seedsigner.hardware.ST7789 import ST7789
 from seedsigner.emulator.desktopDisplay import desktopDisplay
 from seedsigner.models.singleton import ConfigurableSingleton
+from seedsigner.models.settings import Settings
+from seedsigner.models.settings_definition import SettingsConstants
 
+DISPLAY_TYPE__ST7789 = "st7789"
+DISPLAY_TYPE__ILI9341 = "ili9341"
+DISPLAY_TYPE__ILI9486 = "ili9486"
+
+ALL_DISPLAY_TYPES = [DISPLAY_TYPE__ST7789, DISPLAY_TYPE__ILI9341, DISPLAY_TYPE__ILI9486]
 
 
 class Renderer(ConfigurableSingleton):

--- a/seedsigner/gui/renderer.py
+++ b/seedsigner/gui/renderer.py
@@ -50,6 +50,7 @@ class Renderer(ConfigurableSingleton):
             self.disp = desktopDisplay(self.display_type, width=int(width), height=int(height))
         else:
             # Modifies the existing instance without creating a new one
+            self.disp.display_type = self.display_type
             self.disp.width = int(width)
             self.disp.height = int(height)
             self.disp.update_geometry()

--- a/seedsigner/gui/renderer.py
+++ b/seedsigner/gui/renderer.py
@@ -23,16 +23,48 @@ class Renderer(ConfigurableSingleton):
         renderer = cls.__new__(cls)
         cls._instance = renderer
 
-        # Eventually we'll be able to plug in other display controllers
-        #renderer.disp = ST7789()
-        renderer.disp = desktopDisplay()
-        renderer.canvas_width = renderer.disp.width
-        renderer.canvas_height = renderer.disp.height
+        renderer.initialize_display() # (compatibility with the merged SeedSigner PR #741)
 
-        renderer.canvas = Image.new('RGB', (renderer.canvas_width, renderer.canvas_height))
-        renderer.draw = ImageDraw.Draw(renderer.canvas)
 
+    def initialize_display(self): # (compatibility with the merged SeedSigner PR #741)
+        # May be called while already running with a previous display driver; must
+        # prevent any other screen writes while we're changing the display driver.
+        self.lock.acquire()
+
+        display_config = Settings.get_instance().get_value(SettingsConstants.SETTING__DISPLAY_CONFIGURATION, default_if_none=True)
+        self.display_type = display_config.split("_")[0]
+        if self.display_type not in ALL_DISPLAY_TYPES:
+            raise Exception(f"Invalid display type: {self.display_type}")
+
+        width, height = display_config.split("_")[1].split("x")
+
+        if self.disp is None:  # Checks if an active instance already exists
+            # If it doesn't exist, creates a new instance
+            self.disp = desktopDisplay(self.display_type, width=int(width), height=int(height))
+        else:
+            # Modifies the existing instance without creating a new one
+            self.disp.width = int(width)
+            self.disp.height = int(height)
+            self.disp.update_geometry()
     
+        if Settings.get_instance().get_value(SettingsConstants.SETTING__DISPLAY_COLOR_INVERTED, default_if_none=True) == SettingsConstants.OPTION__ENABLED:
+            self.disp.invert()
+
+        if self.display_type == DISPLAY_TYPE__ST7789:
+            self.canvas_width = self.disp.width
+            self.canvas_height = self.disp.height
+
+        elif self.display_type in [DISPLAY_TYPE__ILI9341, DISPLAY_TYPE__ILI9486]:
+            # Swap for the natively portrait-oriented displays
+            self.canvas_width = self.disp.height
+            self.canvas_height = self.disp.width
+
+        self.canvas = Image.new('RGB', (self.canvas_width, self.canvas_height))
+        self.draw = ImageDraw.Draw(self.canvas)
+
+        self.lock.release()
+
+        
     def show_image(self, image=None, alpha_overlay=None, show_direct=False):
         if show_direct:
             # Use the incoming image as the canvas and immediately render


### PR DESCRIPTION
Fixes https://github.com/enteropositivo/seedsigner-emulator/issues/14. This PR aims to adapt the code for the last https://github.com/SeedSigner/seedsigner/pull/741 merged for full execution and to avoid layering errors:

- Error in screensaver call.
- Error calling new renderer.disp object when a new hardware/display feature is used.
- Code adaptation for feature works doing some display size changes, updating image, canvas, Tk elements, buttons, and positions. New methods and internal driver calls are also needed:

https://github.com/user-attachments/assets/e5bf94fa-34ef-47de-bf81-666eecdd461e

Only the files in this repository need to be changed:
- renderer.py
- desktopDisplay.py

This adaptation would help developers ensure compatibility with future SeedSigner updates.
**(tested on Kali Linux Live with python 3.12)**

Best Regards. -